### PR TITLE
Fix typos in English docs

### DIFF
--- a/en/source/data/bls.md
+++ b/en/source/data/bls.md
@@ -10,7 +10,7 @@ It provides macroeconomic data in several interesting categories:
 - compensation and working conditions and productivity.
 
 Quantiacs has implemented these datasets on its cloud and makes them also available for local use on your machine. For
-more informations on using the Quantiacs toolbox and datasets offline, please read
+more information on using the Quantiacs toolbox and datasets offline, please read
 our [instructions](https://quantiacs.com/documentation/en/user_guide/local_development.html) on local installation.
 
 ```python

--- a/en/source/data/stocks.md
+++ b/en/source/data/stocks.md
@@ -130,7 +130,7 @@ qnout.write(weights) # to participate in the competition
 
 ## Stocks NASDAQ100
 
-Quantiacs provides historic, split adjusted, data for more than 250 stocks, all have been **NASDAQ100** index constituents at some point from 2001. (the beggining of index membership data). Most of stocks from the set are still active, but part of them aren't, and the main reason for keeping them still is to avoid survivorship bias occurence.
+Quantiacs provides historic, split adjusted, data for more than 250 stocks, all have been **NASDAQ100** index constituents at some point from 2001. (the beginning of index membership data). Most of stocks from the set are still active, but part of them aren't, and the main reason for keeping them still is to avoid survivorship bias occurrence.
 
 ```python
 import qnt.data as qndata

--- a/en/source/reference/evaluation.md
+++ b/en/source/reference/evaluation.md
@@ -134,7 +134,7 @@ None, only warning messages will be displayed.
 
 ## Multi-Pass Backtesting
 
-We provide you with a function for performing an optional backtesting which explicitely forbids looking-forward issues
+We provide you with a function for performing an optional backtesting which explicitly forbids looking-forward issues
 with a multi-pass implementation where at timestamp "t" only data until timestamp "t" are available by construction. It
 can be used with:
 
@@ -389,7 +389,7 @@ qnout.write(weights)
 ```
 
 After the weights have been computed, you can calculate the statistics in order to evaluate the algorithm in the
-In-Sample perios using:
+In-Sample periods using:
 
 ```python
 stat = qnstats.calc_stat(data, weights.sel(time=slice("2006-01-01", None)))

--- a/en/source/reference/improve_algorithm.md
+++ b/en/source/reference/improve_algorithm.md
@@ -2,7 +2,7 @@
 
 ## Exposure improving
 
-If the algorithm does not pass the [exposure filter](https://quantiacs.io/documentation/en/improve/max-sw.html), one may use one of the two options bellow:
+If the algorithm does not pass the [exposure filter](https://quantiacs.io/documentation/en/improve/max-sw.html), one may use one of the two options below:
 
 ### Remove days with high exposures
 

--- a/en/source/theory/theoretical_basis.md
+++ b/en/source/theory/theoretical_basis.md
@@ -147,7 +147,7 @@ buy/sell a specific number of shares at a specific price. We calculate
 *slippage* according to the following formula:
 
 ```math
-\label{slappage}
+\label{slippage}
     \text{slippage}[i] = abs(\textbf{pos}[i] - \textbf{pos}[i-1])\cdot \textbf{ATR}(14) \cdot 0.05,
 ```
 where ``$` \textbf{ATR}(14) `$`` - is a market volatility indicator. The Average True Range (``$` \textbf{ATR}(N) `$``) indicator is a moving average (MA) over N
@@ -255,7 +255,7 @@ r_{XY} = \frac{\text{cov}_{\textbf{X}\textbf{Y}}}{\sigma_{\textbf{X}} \sigma_{\t
 
 **Competition**
 
-  The performace of a good algorithm OS does not degradate respect to the IS period.
+  The performance of a good algorithm OS does not degrade compared to the IS period.
 
 ![IS OS](./pictures/home_competition_main_isos.png)
 

--- a/en/source/user_guide/data.md
+++ b/en/source/user_guide/data.md
@@ -7,7 +7,7 @@ Quantiacs provides historical data for the world's major financial markets. Curr
 
 ----
 ## Stocks
-Quantiacs provides historic, split adjusted, data for more than 250 stocks, all have been **NASDAQ100** index constituents at some point from 2001. (the beggining of index membership data). Most of stocks from the set are still active, but part of them aren't, and the main reason for keeping them still is to avoid survivorship bias occurence.
+Quantiacs provides historic, split adjusted, data for more than 250 stocks, all have been **NASDAQ100** index constituents at some point from 2001. (the beginning of index membership data). Most of stocks from the set are still active, but part of them aren't, and the main reason for keeping them still is to avoid survivorship bias occurrence.
 
 ### Stocks list
 For getting the list of available stocks, load_ndx_list() method is used. By default, without passing any argument, the method returns only the list of stock objects (dictionaries), which have been index members in last 4 years from now (default, tail=4*365). For filtering the list to some specific period, pass appropriate values to arguments:
@@ -107,7 +107,7 @@ stocks_data = qndata.stocks.load_ndx_data(min_date='2006-01-01', dims=('time', '
 
 - **time**: series of dates in string format 'yyyy-mm-dd'
 - **asset**: list of instruments in string format, combination of first 3 characters of stock exchange and ticker symbol
-- **field**: atribute in End of Day quality
+- **field**: attribute in End of Day quality
 
 
 

--- a/en/source/user_guide/data_stocks.md
+++ b/en/source/user_guide/data_stocks.md
@@ -6,7 +6,7 @@ Quantiacs provides data for companies listed on the NYSE and NASDAQ. Here we wil
 - [Fundamental data](#fundamental-data)
 
 ## General information about tickers
-The informations about the available stocks in the last 5 years can be obtained specifying the lookback period in calendar days multiplied by the number of years:
+The information about the available stocks in the last 5 years can be obtained specifying the lookback period in calendar days multiplied by the number of years:
 
 ```python
 import qnt.data as qndata 

--- a/en/source/user_guide/macro.md
+++ b/en/source/user_guide/macro.md
@@ -8,7 +8,7 @@ Quantiacs provides historical macroeconomic datasets. Currently the datasets fro
 
 ## Bureau of Labor Statistics data
 
-The [**U.S. Bureau of Labor Statistics**](https://www.bls.gov) is the principal agency for the U.S. government in the field of labor economics and statistics. It provides macroeconomic data in several interesting categories: prices, employment and unemployment, compensation and working conditions and productivity. Quantiacs has implemented these datasets on its cloud and makes them also available for local use on your machine. For more informations on using the Quantiacs toolbox and datasets offline, please read our [instructions](https://quantiacs.com/documentation/en/user_guide/local_development.html) on local installation.
+The [**U.S. Bureau of Labor Statistics**](https://www.bls.gov) is the principal agency for the U.S. government in the field of labor economics and statistics. It provides macroeconomic data in several interesting categories: prices, employment and unemployment, compensation and working conditions and productivity. Quantiacs has implemented these datasets on its cloud and makes them also available for local use on your machine. For more information on using the Quantiacs toolbox and datasets offline, please read our [instructions](https://quantiacs.com/documentation/en/user_guide/local_development.html) on local installation.
 
 ----
 

--- a/en/source/user_guide/optimization.md
+++ b/en/source/user_guide/optimization.md
@@ -199,14 +199,14 @@ for an interactive chart of the result
 
 ### Stats function
 
-If you want different statistics than the stadard metrics you need to design a function with this skeleton and provide it as input parameter to **optimize_strategy** (example: **stats_function=stats_function**):
+If you want different statistics than the standard metrics you need to design a function with this skeleton and provide it as input parameter to **optimize_strategy** (example: **stats_function=stats_function**):
 ```Python
 def stats_function(data, output):
     """
     Calculates statistics for the iteration output.
     :param data: market data
     :param output: weights
-    :return: dictionary of statisctics
+    :return: dictionary of statistics
     """
 ```
 

--- a/en/source/user_guide/passFilters.md
+++ b/en/source/user_guide/passFilters.md
@@ -42,7 +42,7 @@ Here are some common mistakes to look out for:
 * Understanding Quantiles
 
 More information:
-* [Different Sharpe Ratios for Multipass-Backtest and Quantiacs Mulipass Backtest](https://quantiacs.com/community/topic/374/different-sharpe-ratios-for-multipass-backtest-and-quantiacs-mulipass-backtest?_=1687248669560)
+* [Different Sharpe Ratios for Multipass-Backtest and Quantiacs Multipass Backtest](https://quantiacs.com/community/topic/374/different-sharpe-ratios-for-multipass-backtest-and-quantiacs-mulipass-backtest?_=1687248669560)
 
 We **recommend** testing your strategy in **multi-pass** mode. [Here is an example](https://quantiacs.com/documentation/en/examples/trading_system_optimization.html#preventing-forward-looking).
 


### PR DESCRIPTION
## Summary
- fix various typos across English markdown documentation

## Testing
- `make -C en html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcc887f7083288092c4188a5d3283